### PR TITLE
Added multi-targetting directives as necessary to handle changes to signatures introduced in Deploy 11.

### DIFF
--- a/src/Vendr.Deploy/Connectors/ServiceConnectors/VendrEntityServiceConnectorBase.cs
+++ b/src/Vendr.Deploy/Connectors/ServiceConnectors/VendrEntityServiceConnectorBase.cs
@@ -43,7 +43,11 @@ namespace Vendr.Deploy.Connectors.ServiceConnectors
 
         public abstract TArtifact GetArtifact(GuidUdi udi, TEntity entity);
 
+#if NET7_0_OR_GREATER
+        public override TArtifact GetArtifact(object o, IContextCache contextCache)
+#else
         public override TArtifact GetArtifact(object o)
+#endif
         {
             var entity = o as TEntity;
             if (entity == null)
@@ -52,7 +56,11 @@ namespace Vendr.Deploy.Connectors.ServiceConnectors
             return GetArtifact(entity.GetUdi(), entity);
         }
 
+#if NET7_0_OR_GREATER
+        public override TArtifact GetArtifact(GuidUdi udi, IContextCache contextCache)
+#else
         public override TArtifact GetArtifact(GuidUdi udi)
+#endif
         {
             EnsureType(udi);
 

--- a/src/Vendr.Deploy/Connectors/ServiceConnectors/VendrEntityServiceConnectorBase.cs
+++ b/src/Vendr.Deploy/Connectors/ServiceConnectors/VendrEntityServiceConnectorBase.cs
@@ -43,11 +43,7 @@ namespace Vendr.Deploy.Connectors.ServiceConnectors
 
         public abstract TArtifact GetArtifact(GuidUdi udi, TEntity entity);
 
-#if NET7_0_OR_GREATER
         public override TArtifact GetArtifact(object o, IContextCache contextCache)
-#else
-        public override TArtifact GetArtifact(object o)
-#endif
         {
             var entity = o as TEntity;
             if (entity == null)
@@ -56,11 +52,7 @@ namespace Vendr.Deploy.Connectors.ServiceConnectors
             return GetArtifact(entity.GetUdi(), entity);
         }
 
-#if NET7_0_OR_GREATER
         public override TArtifact GetArtifact(GuidUdi udi, IContextCache contextCache)
-#else
-        public override TArtifact GetArtifact(GuidUdi udi)
-#endif
         {
             EnsureType(udi);
 

--- a/src/Vendr.Deploy/Connectors/ValueConnectors/VendrVariantsEditorValueConnector.cs
+++ b/src/Vendr.Deploy/Connectors/ValueConnectors/VendrVariantsEditorValueConnector.cs
@@ -19,7 +19,11 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
     /// <summary>
     /// A Deploy connector for the Vendr Variants Editor property editor
     /// </summary>
+#if NET7_0_OR_GREATER
+    public class VendrVariantsEditorValueConnector : BlockEditorValueConnector, IValueConnector2
+#else
     public class VendrVariantsEditorValueConnector : BlockEditorValueConnector, IValueConnector
+#endif
     {
         private readonly IVendrApi _vendrApi;
 
@@ -34,9 +38,15 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             _vendrApi = vendrApi;
         }
 
+#if NET7_0_OR_GREATER
+        public new string ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
+        {
+            var artifact = base.ToArtifact(value, propertyType, dependencies, contextCache);
+#else
         public new string ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
         {
             var artifact = base.ToArtifact(value, propertyType, dependencies);
+#endif
 
             if (string.IsNullOrWhiteSpace(artifact) || !artifact.DetectIsJson())
                 return null;
@@ -78,10 +88,15 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             return artifact;
         }
 
+#if NET7_0_OR_GREATER
+        public new object FromArtifact(string value, IPropertyType propertyType, object currentValue, IContextCache contextCache)
+        {
+            var entity = base.FromArtifact(value, propertyType, currentValue, contextCache);
+#else
         public new object FromArtifact(string value, IPropertyType propertyType, object currentValue)
         {
             var entity = base.FromArtifact(value, propertyType, currentValue);
-
+#endif
             var jObj = entity as JObject;
             if (jObj != null && !string.IsNullOrWhiteSpace(value) && value.DetectIsJson())
             {
@@ -95,11 +110,19 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             return jObj ?? entity;
         }
 
+#if NET7_0_OR_GREATER
+        object IValueConnector2.FromArtifact(string value, IPropertyType propertyType, object currentValue, IContextCache contextCache)
+            => FromArtifact(value, propertyType, currentValue, contextCache);
+
+        string IValueConnector2.ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
+            => ToArtifact(value, propertyType, dependencies, contextCache);
+#else
         object IValueConnector.FromArtifact(string value, IPropertyType propertyType, object currentValue)
             => FromArtifact(value, propertyType, currentValue);
 
         string IValueConnector.ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
             => ToArtifact(value, propertyType, dependencies);
+#endif
 
         public class BaseValue
         {

--- a/src/Vendr.Deploy/Connectors/ValueConnectors/VendrVariantsEditorValueConnector.cs
+++ b/src/Vendr.Deploy/Connectors/ValueConnectors/VendrVariantsEditorValueConnector.cs
@@ -19,11 +19,7 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
     /// <summary>
     /// A Deploy connector for the Vendr Variants Editor property editor
     /// </summary>
-#if NET7_0_OR_GREATER
     public class VendrVariantsEditorValueConnector : BlockEditorValueConnector, IValueConnector2
-#else
-    public class VendrVariantsEditorValueConnector : BlockEditorValueConnector, IValueConnector
-#endif
     {
         private readonly IVendrApi _vendrApi;
 
@@ -38,15 +34,9 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             _vendrApi = vendrApi;
         }
 
-#if NET7_0_OR_GREATER
         public new string ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
         {
             var artifact = base.ToArtifact(value, propertyType, dependencies, contextCache);
-#else
-        public new string ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
-        {
-            var artifact = base.ToArtifact(value, propertyType, dependencies);
-#endif
 
             if (string.IsNullOrWhiteSpace(artifact) || !artifact.DetectIsJson())
                 return null;
@@ -88,15 +78,9 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             return artifact;
         }
 
-#if NET7_0_OR_GREATER
         public new object FromArtifact(string value, IPropertyType propertyType, object currentValue, IContextCache contextCache)
         {
             var entity = base.FromArtifact(value, propertyType, currentValue, contextCache);
-#else
-        public new object FromArtifact(string value, IPropertyType propertyType, object currentValue)
-        {
-            var entity = base.FromArtifact(value, propertyType, currentValue);
-#endif
             var jObj = entity as JObject;
             if (jObj != null && !string.IsNullOrWhiteSpace(value) && value.DetectIsJson())
             {
@@ -110,19 +94,11 @@ namespace Vendr.Deploy.Connectors.ValueConnectors
             return jObj ?? entity;
         }
 
-#if NET7_0_OR_GREATER
         object IValueConnector2.FromArtifact(string value, IPropertyType propertyType, object currentValue, IContextCache contextCache)
             => FromArtifact(value, propertyType, currentValue, contextCache);
 
         string IValueConnector2.ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)
             => ToArtifact(value, propertyType, dependencies, contextCache);
-#else
-        object IValueConnector.FromArtifact(string value, IPropertyType propertyType, object currentValue)
-            => FromArtifact(value, propertyType, currentValue);
-
-        string IValueConnector.ToArtifact(object value, IPropertyType propertyType, ICollection<ArtifactDependency> dependencies)
-            => ToArtifact(value, propertyType, dependencies);
-#endif
 
         public class BaseValue
         {

--- a/src/Vendr.Deploy/Vendr.Deploy.csproj
+++ b/src/Vendr.Deploy/Vendr.Deploy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Authors>Vendr, Outfield Digital Ltd</Authors>
         <Company>Outfield Digital Ltd</Company>
         <Copyright>Outfield Digital Ltd</Copyright>
@@ -16,11 +16,19 @@
 
     <ItemGroup>
         <PackageReference Include="Vendr.Umbraco.Startup" Version="3.0.0" />
-        <PackageReference Include="Umbraco.Deploy.Infrastructure" Version="10.0.1" />
-        <PackageReference Include="Umbraco.Deploy.Contrib" Version="10.0.0" />
     </ItemGroup>
 
-    <!-- Workaround for this bug (replace the analyzer name with the one you need to exclude (filename only, no extension) -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Umbraco.Deploy.Infrastructure" Version="10.0.1" />
+		<PackageReference Include="Umbraco.Deploy.Contrib" Version="10.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="Umbraco.Deploy.Infrastructure" Version="11.0.0" />
+		<PackageReference Include="Umbraco.Deploy.Contrib" Version="11.0.0" />
+	</ItemGroup>
+
+	<!-- Workaround for this bug (replace the analyzer name with the one you need to exclude (filename only, no extension) -->
     <Target Name="RemoveLuceneAnalyzer" BeforeTargets="CoreCompile">
         <ItemGroup>
             <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Lucene.Net.CodeAnalysis.CSharp'" />

--- a/src/Vendr.Deploy/Vendr.Deploy.csproj
+++ b/src/Vendr.Deploy/Vendr.Deploy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net7.0</TargetFrameworks>
         <Authors>Vendr, Outfield Digital Ltd</Authors>
         <Company>Outfield Digital Ltd</Company>
         <Copyright>Outfield Digital Ltd</Copyright>
@@ -16,14 +16,6 @@
 
     <ItemGroup>
         <PackageReference Include="Vendr.Umbraco.Startup" Version="3.0.0" />
-    </ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Umbraco.Deploy.Infrastructure" Version="10.0.1" />
-		<PackageReference Include="Umbraco.Deploy.Contrib" Version="10.0.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 		<PackageReference Include="Umbraco.Deploy.Infrastructure" Version="11.0.0" />
 		<PackageReference Include="Umbraco.Deploy.Contrib" Version="11.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
I'm not 100% you want to use the multi-targeting approach moving forward, but I've used it here.  It's fine for Umbraco 10 and 11, but it's been pointed out to me in review that moving forward can't necessarily be used for future majors as Umbraco 12 will also run on .NET 7.  So you may prefer to split these changes into a separate branch and a new major version supporting Umbraco 11.

I'm afraid this is untested as I don't have a Cloud/Vendr setup to test on, but it at least compiles and handles the changed signatures.